### PR TITLE
feat(thebe): tracking code block interaction

### DIFF
--- a/frontend/constants/segment.ts
+++ b/frontend/constants/segment.ts
@@ -38,3 +38,14 @@ export interface PerformedSearchEventSegmentSchema
   extends IbmCloudCommonEventSegmentSchema {
   field: string
 }
+
+/**
+ * Properties sent to Segment for the event "Updated Object".
+ * Only the properties used in this project are included in this interface.
+ * https://segment-standards.prod.ddp.cis.ibm.net/events/updated-object
+ */
+export interface UpdatedObjectEventSegmentSchema
+ extends IbmCloudCommonEventSegmentSchema {
+  object: string
+  objectType: string
+}

--- a/frontend/plugins/segmentAnalytics.ts
+++ b/frontend/plugins/segmentAnalytics.ts
@@ -1,7 +1,8 @@
 
 import {
   CtaClickedEventSegmentSchema,
-  PerformedSearchEventSegmentSchema
+  PerformedSearchEventSegmentSchema,
+  UpdatedObjectEventSegmentSchema
 } from '../constants/segment'
 
 /**
@@ -136,6 +137,30 @@ function trackPerformedSearch (uiElement: string, field: string) {
   bluemixAnalytics.trackEvent('Performed Search', eventOptions)
 }
 
+/**
+ * Send the information of a "Updated Object" event to Segment.
+ * @param context Bluemix Analytics configuration
+ * @param objectType Type of object that was updated
+ * @param object Object that was updated
+ */
+function trackUpdatedObject (objectType: string, object: string) {
+  const { bluemixAnalytics, digitalData } = window
+
+  if (!bluemixAnalytics || !digitalData) { return }
+
+  const productTitle = getOrFailProductTitle(digitalData)
+  const category = getOrFailCategory(digitalData)
+
+  const eventOptions: UpdatedObjectEventSegmentSchema = {
+    category,
+    productTitle,
+    object,
+    objectType
+  }
+
+  bluemixAnalytics.trackEvent('Updated Object', eventOptions)
+}
+
 function getOrFailProductTitle (digitalData: any): string {
   return assertCanGet(
     () => digitalData.page.pageInfo.productTitle,
@@ -171,6 +196,7 @@ function install (app: any, _options: any = {}) {
   app.config.globalProperties.$trackClickEvent = trackClickEvent
   app.config.globalProperties.$trackPage = trackPage
   app.config.globalProperties.$trackPerformedSearch = trackPerformedSearch
+  app.config.globalProperties.$trackUpdatedObject = trackUpdatedObject
 }
 
 export {
@@ -178,7 +204,8 @@ export {
   install,
   trackClickEvent,
   trackPage,
-  trackPerformedSearch
+  trackPerformedSearch,
+  trackUpdatedObject
 }
 
 export type {

--- a/frontend/textbook.ts
+++ b/frontend/textbook.ts
@@ -4,7 +4,13 @@ import { initIndexHighlight } from './ts/indexhighlighter'
 import { initNotations } from './ts/notations'
 import { initLeftSidebar, toggleLanguagePicker } from './ts/leftsidebar'
 import { getProgressData, storeProgressLocally } from './ts/storage'
-import { initAnalytics, trackClickEvent, trackPage, trackPerformedSearch } from './plugins/segmentAnalytics'
+import {
+  initAnalytics,
+  trackClickEvent,
+  trackPage,
+  trackPerformedSearch,
+  trackUpdatedObject
+} from './plugins/segmentAnalytics'
 import { loadTranslations } from './ts/translations'
 
 
@@ -19,6 +25,7 @@ interface Textbook {
   runAfterDOMLoaded: any,
   trackClickEvent?: any,
   trackPerformedSearch?: any,
+  trackUpdatedObject?: any,
   course?: XCourse,
   locale: string,
   translations?: {[x:string]: string}
@@ -61,5 +68,6 @@ textbook.runAfterDOMLoaded(() => {
   initAnalytics(window.textbookAnalytics.key, window.textbookAnalytics.url)
   textbook.trackClickEvent = trackClickEvent
   textbook.trackPerformedSearch = trackPerformedSearch
+  textbook.trackUpdatedObject = trackUpdatedObject
   trackPage(window.location.pathname)
 })

--- a/server/includes/thebe-init.js
+++ b/server/includes/thebe-init.js
@@ -1,6 +1,25 @@
+/**
+ * Set up Segment tracking when running the code in a code cell.
+ *
+ * @param {Element} runButtonElement
+ * @param {number} codeCellIndex
+ */
+function setupCodeRunningTracking (runButtonElement, codeCellIndex) {
+  const codeCellId = codeCellIndex + 1
+
+  runButtonElement.addEventListener('click', () => {
+    window.textbook.trackClickEvent('Run', `Code cell #${codeCellId}`)
+  })
+}
 
 const initializeCodeCells = function () {
   thebelab.bootstrap()
+
+  document.querySelectorAll('.thebelab-cell').forEach((codeCell, index) => {
+    const runButtonElement = codeCell.querySelector('.thebelab-run-button')
+
+    setupCodeRunningTracking(runButtonElement, index)
+  })
 
   document
     .querySelectorAll('.thebelab-cell')

--- a/server/includes/thebe-init.js
+++ b/server/includes/thebe-init.js
@@ -1,9 +1,7 @@
 
 const initializeCodeCells = function () {
   thebelab.bootstrap()
-  thebelab.on('status', function (evt, data) {
-    console.log('Thebelab status changed:', data.status, data.message)
-  })
+
   document
     .querySelectorAll('.thebelab-cell')
     .forEach((codeCell) => {

--- a/server/includes/thebe-init.js
+++ b/server/includes/thebe-init.js
@@ -1,4 +1,24 @@
 /**
+ * Set up Segment tracking when the code in a code cell is modified for the
+ * first time.
+ *
+ * @param {CodeMirror} codeMirrorInstance
+ * @param {number} codeCellIndex
+ */
+function setupCodeModifiedTracking (codeMirrorInstance, codeCellIndex) {
+  const codeCellId = codeCellIndex + 1
+
+  codeMirrorInstance.on('beforeChange', () => {
+    if (codeMirrorInstance.isClean()) {
+      window.textbook.trackUpdatedObject(
+        'Code cell',
+        `Code cell #${codeCellId}`
+      )
+    }
+  })
+}
+
+/**
  * Set up Segment tracking when running the code in a code cell.
  *
  * @param {Element} runButtonElement
@@ -15,14 +35,20 @@ function setupCodeRunningTracking (runButtonElement, codeCellIndex) {
 const initializeCodeCells = function () {
   thebelab.bootstrap()
 
-  document.querySelectorAll('.thebelab-cell').forEach((codeCell, index) => {
-    const runButtonElement = codeCell.querySelector('.thebelab-run-button')
-
-    setupCodeRunningTracking(runButtonElement, index)
-  })
+  const codeCellSelector = '.thebelab-cell'
 
   document
-    .querySelectorAll('.thebelab-cell')
+    .querySelectorAll(codeCellSelector)
+    .forEach((codeCell, codeCellIndex) => {
+      const codeMirrorInstance = codeCell.querySelector('.CodeMirror').CodeMirror
+      const runButtonElement = codeCell.querySelector('.thebelab-run-button')
+
+      setupCodeModifiedTracking(codeMirrorInstance, codeCellIndex)
+      setupCodeRunningTracking(runButtonElement, codeCellIndex)
+    })
+
+  document
+    .querySelectorAll(codeCellSelector)
     .forEach((codeCell) => {
       codeCell.querySelector('.thebelab-restart-button').remove()
       codeCell.querySelector('.thebelab-restartall-button').remove()
@@ -57,7 +83,7 @@ const initializeCodeCells = function () {
    * Avoid translating code.
    */
   document
-    .querySelectorAll('.thebelab-cell')
+    .querySelectorAll(codeCellSelector)
     .forEach((thebelabCell) => {
       thebelabCell.setAttribute('translate', 'no')
     })
@@ -66,7 +92,7 @@ const initializeCodeCells = function () {
    * Copy to clipboard functionality.
    */
   document
-    .querySelectorAll('.thebelab-cell')
+    .querySelectorAll(codeCellSelector)
     .forEach((thebelabCell, index) => {
       const codeCellId = `code-mirror-element-${index}`
 

--- a/server/includes/thebe-init.js
+++ b/server/includes/thebe-init.js
@@ -1,4 +1,29 @@
 /**
+ * Prevents the automatic translation of a given element.
+ *
+ * @param {Element} element
+ */
+function preventTranslation (element) {
+  element.setAttribute('translate', 'no')
+}
+
+/**
+ * Setup up the indicator that shows the code cell is running.
+ *
+ * @param {Element} runButton
+ * @param {Element} busyStateIndicator
+ */
+function setupCodeRunningIndicator (runButton, busyStateIndicator) {
+  const busySpan = document.createElement('span')
+
+  busySpan.classList.add('thebelab-busy-text')
+  busySpan.textContent = 'Running'
+
+  busyStateIndicator.append(busySpan)
+  runButton.append(busyStateIndicator)
+}
+
+/**
  * Set up Segment tracking when the code in a code cell is modified for the
  * first time.
  *
@@ -21,15 +46,48 @@ function setupCodeModifiedTracking (codeMirrorInstance, codeCellIndex) {
 /**
  * Set up Segment tracking when running the code in a code cell.
  *
- * @param {Element} runButtonElement
+ * @param {Element} runButton
  * @param {number} codeCellIndex
  */
-function setupCodeRunningTracking (runButtonElement, codeCellIndex) {
+function setupCodeRunningTracking (runButton, codeCellIndex) {
   const codeCellId = codeCellIndex + 1
 
-  runButtonElement.addEventListener('click', () => {
+  runButton.addEventListener('click', () => {
     window.textbook.trackClickEvent('Run', `Code cell #${codeCellId}`)
   })
+}
+
+/**
+ * Set up the "copy to clipboard" functionality for a code cell.
+ *
+ * @param {Element} codeCell
+ * @param {number} codeCellIndex
+ * @param {NodeListOf<Element>} cellCodeLines
+ */
+function setupCopyToClipboard (codeCell, codeCellIndex, cellCodeLines) {
+  const codeCellId = `code-mirror-element-${codeCellIndex}`
+
+  const clipboardCopyComponent = document.createElement(
+    'q-code-mirror-clipboard-copy'
+  )
+  clipboardCopyComponent.setAttribute('target-id', codeCellId)
+  codeCell.append(clipboardCopyComponent)
+
+  const codeInput = document.createElement('input')
+  codeInput.id = codeCellId
+  codeCell.append(codeInput)
+
+  /**
+   * Create a copy of the CodeMirror cell's content adding line breaks.
+   * The "copy to clipboard" functionality will copy the content from this
+   * copy.
+   */
+  const codeLines = Array.from(cellCodeLines).map(
+    codeLine => codeLine.textContent
+  )
+  const formattedCode = codeLines.join('\n')
+  codeInput.setAttribute('type', 'hidden')
+  codeInput.setAttribute('value', formattedCode)
 }
 
 const initializeCodeCells = function () {
@@ -40,84 +98,32 @@ const initializeCodeCells = function () {
   document
     .querySelectorAll(codeCellSelector)
     .forEach((codeCell, codeCellIndex) => {
+      const busyStateIndicator = codeCell.querySelector('.thebelab-busy')
+      const cellCode = codeCell.querySelector('.CodeMirror-code')
+      const cellCodeLines = cellCode.querySelectorAll('.CodeMirror-line')
+      const cellInput = codeCell.querySelector('.thebelab-input')
+      const cellOutput = codeCell.querySelector('.jp-OutputArea')
       const codeMirrorInstance = codeCell.querySelector('.CodeMirror').CodeMirror
-      const runButtonElement = codeCell.querySelector('.thebelab-run-button')
+      const restartButton = codeCell.querySelector('.thebelab-restart-button')
+      const restartAllButton = codeCell.querySelector('.thebelab-restartall-button')
+      const runButton = codeCell.querySelector('.thebelab-run-button')
 
-      setupCodeModifiedTracking(codeMirrorInstance, codeCellIndex)
-      setupCodeRunningTracking(runButtonElement, codeCellIndex)
-    })
+      restartButton.remove()
+      restartAllButton.remove()
 
-  document
-    .querySelectorAll(codeCellSelector)
-    .forEach((codeCell) => {
-      codeCell.querySelector('.thebelab-restart-button').remove()
-      codeCell.querySelector('.thebelab-restartall-button').remove()
-
-      const codeCellRunButton = codeCell.querySelector('.thebelab-run-button')
-      codeCellRunButton.setAttribute('data-test', 'code-cell-button-run')
-      codeCellRunButton.textContent = 'Run'
-
-      const codeCellBusyIndicator = codeCell.querySelector('.thebelab-busy')
-      const busySpan = document.createElement('span')
-      busySpan.classList.add('thebelab-busy-text')
-      busySpan.textContent = 'Running'
-      codeCellBusyIndicator.append(busySpan)
-      codeCellRunButton.append(codeCellBusyIndicator)
+      runButton.textContent = 'Run'
 
       codeCell.setAttribute('data-test', 'code-cell')
+      cellCode.setAttribute('data-test', 'code-cell-code')
+      cellInput.setAttribute('data-test', 'code-cell-input')
+      cellOutput.setAttribute('data-test', 'code-cell-output')
+      runButton.setAttribute('data-test', 'code-cell-button-run')
 
-      codeCell
-        .querySelector('.thebelab-input')
-        .setAttribute('data-test', 'code-cell-input')
-
-      codeCell
-        .querySelector('.jp-OutputArea')
-        .setAttribute('data-test', 'code-cell-output')
-
-      codeCell
-        .querySelector('.CodeMirror-code')
-        .setAttribute('data-test', 'code-cell-code')
-    })
-
-  /**
-   * Avoid translating code.
-   */
-  document
-    .querySelectorAll(codeCellSelector)
-    .forEach((thebelabCell) => {
-      thebelabCell.setAttribute('translate', 'no')
-    })
-
-  /**
-   * Copy to clipboard functionality.
-   */
-  document
-    .querySelectorAll(codeCellSelector)
-    .forEach((thebelabCell, index) => {
-      const codeCellId = `code-mirror-element-${index}`
-
-      const clipboardCopyComponent = document.createElement(
-        'q-code-mirror-clipboard-copy'
-      )
-      clipboardCopyComponent.setAttribute('target-id', codeCellId)
-      thebelabCell.append(clipboardCopyComponent)
-
-      const codeInput = document.createElement('input')
-      codeInput.id = codeCellId
-      thebelabCell.append(codeInput)
-
-      /**
-       * Create a copy of the CodeMirror cell's content adding line breaks.
-       * The "copy to clipboard" functionality will copy the content from this
-       * copy.
-       */
-      const codeElement = thebelabCell.querySelector('.CodeMirror-code')
-      const codeLines = Array.from(
-        codeElement.querySelectorAll('.CodeMirror-line')
-      ).map(codeLine => codeLine.textContent)
-      const formattedCode = codeLines.join('\n')
-      codeInput.setAttribute('type', 'hidden')
-      codeInput.setAttribute('value', formattedCode)
+      preventTranslation(codeCell)
+      setupCodeRunningIndicator(runButton, busyStateIndicator)
+      setupCodeModifiedTracking(codeMirrorInstance, codeCellIndex)
+      setupCodeRunningTracking(runButton, codeCellIndex)
+      setupCopyToClipboard(codeCell, codeCellIndex, cellCodeLines)
     })
 }
 


### PR DESCRIPTION
This PR sets up Segment tracking events to track when the code in a code cell is ran, and when it has been modified.

We're using Segment events available in our IBM schema.

For the **code running** event, we're sending the `CTA Clicked` event with the following information:

- cta: `Run`
- location: `Code cell #<number of code cell on the page>`

For the **code modified** event, we're sending the `Updated Object` event with the following information:

- objectType: `Code cell`
- object: `Code cell #<number of code cell on the page>`

This PR also introduces a refactory with https://github.com/qiskit-community/platypus/commit/76ec806d4188c25132558d2139855044efee47fe in order to improve the time and space complexity of the code executed during the initialisation of Thebe.

---

Closes https://github.com/Qiskit/qiskit.org/issues/2162