### PR TITLE
update summer school content url

### DIFF
--- a/notebooks/toc.yaml
+++ b/notebooks/toc.yaml
@@ -263,8 +263,8 @@
       id: project
       url: /intro/project
 
-- title: Summer school 2021
-  url: /qgss2021
+- title: Summer School 2021
+  url: /2021
   type: learning-path
   sections:
     - title: Vector Spaces, Tensor Products, and Qubits

--- a/server/app.ts
+++ b/server/app.ts
@@ -84,6 +84,11 @@ new MathigonStudioApp()
     // :section - refers to the lecture id
     const courseData = await getCourseData(req)
 
+    courseData?.course.sections.forEach(section => {
+      // Mathigon by default set url as 'course/'
+      section.url = section.url.replace('course/', 'summer-school/')
+    })
+
     if (!courseData) {
       return next()
     } else {

--- a/server/app.ts
+++ b/server/app.ts
@@ -73,6 +73,11 @@ new MathigonStudioApp()
     })
     next()
   })
+  .get('/summer-school/:course', (req, res, next) => {
+    // redirect to first lecture when no lecture specified
+    const course = getCourse(req.params.course, req.locale.id)
+    return course ? res.redirect(`/summer-school/${course.id}/${course.sections[0].id}`) : next();
+  })
   .get('/summer-school/:course/:section', async(req, res, next) => {
     // example URL: /summer-school/2021/lec1-2
     // :course - refers to the summer school year

--- a/server/app.ts
+++ b/server/app.ts
@@ -2,6 +2,8 @@
 // Project Platypus
 // =============================================================================
 
+import { Request } from 'express';
+
 import { MathigonStudioApp } from '@mathigon/studio/server/app'
 import { getCourse } from '@mathigon/studio/server/utilities'
 
@@ -13,6 +15,45 @@ import {
 import * as storageApi from './storage'
 
 import { translate } from '@mathigon/studio/server/i18n'
+
+const getCourseData = async function (req: Request) {
+  const course = getCourse(req.params.course, req.locale.id)
+  const section = course?.sections.find(s => s.id === req.params.section)
+
+  if (!course || !section) { return null }
+
+  const lang = course.locale || 'en'
+  const learningPath = isLearningPath(course)
+
+  const response = await storageApi.getProgressData?.(req, course, section)
+  const progressJSON = JSON.stringify(response?.data || {})
+  const notationsJSON = JSON.stringify(NOTATIONS[lang] || {})
+  const universalJSON = JSON.stringify(UNIVERSAL_NOTATIONS[lang] || {})
+  const translationsJSON = JSON.stringify(TRANSLATIONS[lang] || {})
+
+  course.glossJSON = updateGlossary(course)
+
+  const nextSection = findNextSection(course, section)
+  const prevSection = findPrevSection(course, section)
+  const subsections = getSectionIndex(course, section)
+
+  return {
+    course,
+    section,
+    config: CONFIG,
+    progressJSON,
+    notationsJSON,
+    learningPath,
+    nextSection,
+    prevSection,
+    universalJSON,
+    translationsJSON,
+    subsections,
+    textbookHome: TEXTBOOK_HOME,
+    // override `__()`  to pass in the course locale instead of default req locale
+    __: (str: string, ...args: string[]) => translate(lang, str, args)
+  }
+}
 
 new MathigonStudioApp()
   .get('/health', (req, res) => res.status(200).send('ok')) // Server Health Checks
@@ -32,43 +73,26 @@ new MathigonStudioApp()
     })
     next()
   })
+  .get('/summer-school/:course/:section', async(req, res, next) => {
+    // example URL: /summer-school/2021/lec1-2
+    // :course - refers to the summer school year
+    // :section - refers to the lecture id
+    const courseData = await getCourseData(req)
+
+    if (!courseData) {
+      return next()
+    } else {
+      res.render('textbook', courseData)
+    }
+  })
   .get('/course/:course/:section', async (req, res, next) => {
-    const course = getCourse(req.params.course, req.locale.id)
-    const section = course?.sections.find(s => s.id === req.params.section)
+    const courseData = await getCourseData(req)
 
-    if (!course || !section) { return next() }
-
-    const lang = course.locale || 'en'
-    const learningPath = isLearningPath(course)
-
-    const response = await storageApi.getProgressData?.(req, course, section)
-    const progressJSON = JSON.stringify(response?.data || {})
-    const notationsJSON = JSON.stringify(NOTATIONS[lang] || {})
-    const universalJSON = JSON.stringify(UNIVERSAL_NOTATIONS[lang] || {})
-    const translationsJSON = JSON.stringify(TRANSLATIONS[lang] || {})
-
-    course.glossJSON = updateGlossary(course)
-
-    const nextSection = findNextSection(course, section)
-    const prevSection = findPrevSection(course, section)
-    const subsections = getSectionIndex(course, section)
-
-    res.render('textbook', {
-      course,
-      section,
-      config: CONFIG,
-      progressJSON,
-      notationsJSON,
-      learningPath,
-      nextSection,
-      prevSection,
-      universalJSON,
-      translationsJSON,
-      subsections,
-      textbookHome: TEXTBOOK_HOME,
-      // override `__()`  to pass in the course locale instead of default req locale
-      __: (str: string, ...args: string[]) => translate(lang, str, args)
-    })
+    if (!courseData) {
+      return next()
+    } else {
+      res.render('textbook', courseData)
+    }
   })
   .course(storageApi)
   .errors()


### PR DESCRIPTION
this PR makes it so the summer school content can be accessed via the URL: `/summer-school/2021/...`

example preview URLs:
- https://platypus-pr-144.ecy0akwlcpw.us-south.codeengine.appdomain.cloud/summer-school/2021
- https://platypus-pr-144.ecy0akwlcpw.us-south.codeengine.appdomain.cloud/summer-school/2021/lec4-1

---

Related:
- https://github.com/qiskit-community/platypus/pull/138
- https://github.com/Qiskit/qiskit.org/issues/2152
