### PR TITLE
repoint binder

### DIFF
--- a/server/includes/thebe-config.html
+++ b/server/includes/thebe-config.html
@@ -1,8 +1,8 @@
 <script type="text/x-thebe-config">{
   requestKernel: true,
   binderOptions: {
-    repo: "qiskit-community/qiskit-textbook",
-    ref: "platypus-binder",
+    repo: "qiskit-community/platypus",
+    ref: "binder-env",
   },
   codeMirrorconfig: {
     lineWrapping: false
@@ -13,7 +13,7 @@
   },
   kernelOptions: {
     kernelName: "python3",
-    path: "./notebooks/intro"
+    path: "."
   },
   mathjaxUrl: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js',
   predefinedOutput: true,


### PR DESCRIPTION
Fixes #148

It seems thebe is ignoring the 'path' and just starting the kernel at the root. This PR works around this by moving the required files to the root too.