### PR TITLE
update megamenu lab links

### DIFF
--- a/cypress/integration/mega-menu-dropdown.spec.js
+++ b/cypress/integration/mega-menu-dropdown.spec.js
@@ -1,6 +1,12 @@
 /// <reference types="cypress" />
 
 describe('Mega menu dropdown', () => {
+  const originRegex = /(.*?:\/\/.*?\/)/
+  const sitemapJson = require('../../public/sitemap.json')
+  const sitemapUrls = sitemapJson.urlset.url.map(({ loc }) => {
+    return loc[0].replace(originRegex, '')
+  })
+
   it('can be opened', () => {
     const megaMenuDropdownSelector = '[data-test=content-menu-dropdown]'
     const megaMenuDropdownContentSelector =
@@ -13,5 +19,17 @@ describe('Mega menu dropdown', () => {
     cy.get(megaMenuDropdownSelector).click()
     cy.get(megaMenuDropdownSelector).should('be.visible')
     cy.get(megaMenuDropdownContentSelector).should('be.visible')
+  })
+
+  it('should contain correct links', () => {
+    // find all links in megamenu
+    cy.get('q-content-menu a').each($a => {
+      // skip the titles
+      if ($a.attr('class').indexOf('link_title') == -1) {
+        const url = $a.attr('href').replace(originRegex, '')
+        // url should match what is in the sitemap
+        expect(url).to.be.oneOf(sitemapUrls)
+      }
+    })
   })
 })

--- a/frontend/vue/components/constants/megaMenuLinks.ts
+++ b/frontend/vue/components/constants/megaMenuLinks.ts
@@ -12,7 +12,7 @@ const sectionApps = 'apps'
 const sectionCircuits = 'circuits'
 const sectionLabs = 'labs'
 
-const baseUrl = 'https://learn.qiskit.org'
+const baseUrl = window && window.location ? window.location.origin : 'https://learn.qiskit.org'
 const pathPrerequisites = '/course/ch-prerequisites'
 const pathQuantumStatesAndQubits = '/course/ch-states'
 const pathMultipleQubitsAndEntanglement = '/course/ch-gates'
@@ -484,45 +484,52 @@ const QUANTUM_COMPUTING_LABS : MegaDropdownMenuGroup = {
       }
     },
     {
-      label: 'Lab 2. Quantum Measurement',
-      url: `${baseUrl}${pathLabs}/lab-2-quantum-measurements`,
+      label: 'Lab 2. Single Quibit Gates',
+      url: `${baseUrl}${pathLabs}/lab-2-single-quibit-gates`,
       segment: {
-        action: `${actionPrefix} > ${sectionLabs} > lab-2-quantum-measurements`
+        action: `${actionPrefix} > ${sectionLabs} > lab-2-single-quibit-gates`
       }
     },
     {
-      label: 'Lab 3. Accuracy of Quantum Phase Estimation',
-      url: `${baseUrl}${pathLabs}/lab-3-accuracy-of-quantum-phase-estimation`,
+      label: 'Lab 3. Quantum Measurement',
+      url: `${baseUrl}${pathLabs}/lab-3-quantum-measurements`,
       segment: {
-        action: `${actionPrefix} > ${sectionLabs} > lab-3-accuracy-of-quantum-phase-estimation`
+        action: `${actionPrefix} > ${sectionLabs} > lab-3-quantum-measurements`
       }
     },
     {
-      label: 'Lab 4. Iterative Quantum Phase Estimation',
-      url: `${baseUrl}${pathLabs}/lab-4-iterative-phase-estimation-algorithm`,
+      label: 'Lab 4. Accuracy of Quantum Phase Estimation',
+      url: `${baseUrl}${pathLabs}/lab-4-accuracy-of-quantum-phase-estimation`,
       segment: {
-        action: `${actionPrefix} > ${sectionLabs} > lab-4-iterative-phase-estimation-algorithm`
+        action: `${actionPrefix} > ${sectionLabs} > lab-4-accuracy-of-quantum-phase-estimation`
       }
     },
     {
-      label: 'Lab 5. Scalable Shor\'s Algorithm',
-      url: `${baseUrl}${pathLabs}/lab-5-scalable-shors-algorithm`,
+      label: 'Lab 5. Iterative Quantum Phase Estimation',
+      url: `${baseUrl}${pathLabs}/lab-5-iterative-phase-estimation-algorithm`,
       segment: {
-        action: `${actionPrefix} > ${sectionLabs} > lab-5-scalable-shors-algorithm`
+        action: `${actionPrefix} > ${sectionLabs} > lab-5-iterative-phase-estimation-algorithm`
       }
     },
     {
-      label: 'Lab 6. Grover\'s search with an unknown number of solutions',
-      url: `${baseUrl}${pathLabs}/lab-6-grovers-search-with-an-unknown-number-of-solutions`,
+      label: 'Lab 6. Scalable Shor\'s Algorithm',
+      url: `${baseUrl}${pathLabs}/lab-6-scalable-shors-algorithm`,
       segment: {
-        action: `${actionPrefix} > ${sectionLabs} > lab-6-grovers-search-with-an-unknown-number-of-solutions`
+        action: `${actionPrefix} > ${sectionLabs} > lab-6-scalable-shors-algorithm`
       }
     },
     {
-      label: 'Lab 7. Quantum Simulation as a Search Algorithm',
-      url: `${baseUrl}${pathLabs}/lab-7-quantum-simulation-as-a-search-algorithm`,
+      label: 'Lab 7. Grover\'s search with an unknown number of solutions',
+      url: `${baseUrl}${pathLabs}/lab-7-grovers-search-with-an-unknown-number-of-solutions`,
       segment: {
-        action: `${actionPrefix} > ${sectionLabs} > lab-7-quantum-simulation-as-a-search-algorithm`
+        action: `${actionPrefix} > ${sectionLabs} > lab-7-grovers-search-with-an-unknown-number-of-solutions`
+      }
+    },
+    {
+      label: 'Lab 8. Quantum Simulation as a Search Algorithm',
+      url: `${baseUrl}${pathLabs}/lab-8-quantum-simulation-as-a-search-algorithm`,
+      segment: {
+        action: `${actionPrefix} > ${sectionLabs} > lab-8-quantum-simulation-as-a-search-algorithm`
       }
     }
   ]


### PR DESCRIPTION
an [update/re-alignment of the labs](https://github.com/qiskit-community/platypus/pull/186) resulted in the URLs changing thus breaking the links in the megamenu.

this PR 
- adds test to check all megamenu links (to catch futures failures sooner)
- updates the lab links in the megamenu drop down

related: https://github.com/Qiskit/qiskit.org/issues/2332 , https://github.com/Qiskit/qiskit.org/pull/2337

---
fyi, in an [upcoming update](https://github.com/qiskit-community/platypus/pull/174) there will be a [new endpoint which returns the list of courses](https://github.com/qiskit-community/platypus/blob/bcdfc0c80fe1d8afba426f74bc8440836beac2bd/server/app.ts#L80-L90). we can perhaps update the megamenu in the future to make use of the endpoint to obtains  the links. this way it needs not be manually updated if the urls/courses changes.

