### PR TITLE
fix: typo

### DIFF
--- a/notebooks/toc.yaml
+++ b/notebooks/toc.yaml
@@ -169,7 +169,7 @@
       id: lab-1-quantum-circuits
       url: /ch-labs/Lab01_QuantumCircuits
     - title: Lab 2. Single Qubit Gates
-      id: lab-2-single-quibit-gates
+      id: lab-2-single-qubit-gates
       url: /ch-labs/Lab02_Single_Qubit_Gates
     - title: Lab 3. Quantum Measurement
       id: lab-3-quantum-measurements


### PR DESCRIPTION
The PR https://github.com/qiskit-community/platypus/pull/186 introduced a typo that generates the link https://learn.qiskit.org/course/ch-labs/lab-2-single-quibit-gates, which should be https://learn.qiskit.org/course/ch-labs/lab-2-single-qubit-gates ("qubit" instead of "quibit").

This PR fixes that typo.