### PR TITLE
Fix code spacing issue

### DIFF
--- a/frontend/scss/vendor/mathigon.scss
+++ b/frontend/scss/vendor/mathigon.scss
@@ -288,6 +288,7 @@ x-progress {
 }
 
 x-step {
+  word-spacing: normal;
   color: $text-color-light;
 
   ul, ol {

--- a/frontend/scss/vendor/thebelab.scss
+++ b/frontend/scss/vendor/thebelab.scss
@@ -120,6 +120,7 @@ div.jb_input div.input {
 x-step {
   .jp-OutputArea-output {
     pre {
+      font-family: $plex-mono;
       margin: 0;
       white-space: pre-wrap;
       word-wrap: break-word;


### PR DESCRIPTION
<img src="https://i.pinimg.com/736x/c4/3d/2d/c43d2d0171fcf40c5558db7c9c768b2d.jpg" width=300> <img src="https://user-images.githubusercontent.com/36071638/146617054-a2b91dc9-3285-4933-b39e-e6a28f6ea56a.png" width=300>

Most notably affecting circuit diagrams, but also was making some indentations align weirdly too. Also set the cell outputs to the IBM Plex Mono font.

